### PR TITLE
Submit/Approve order

### DIFF
--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -1,0 +1,25 @@
+class Mutations::SubmitOrder < Mutations::BaseMutation
+  null true
+
+  argument :id, String, required: true
+  argument :shipping_info, String, required: false
+  argument :credit_card_id, String, required: true
+
+  field :order, Types::OrderType, null: true
+  field :errors, [String], null: false
+
+  def resolve(id:, shipping_info:, credit_card_id:)
+    order = Order.find(id)
+    validate_request!(order)
+    {
+      order: OrderService.submit!(order, user_id: user_id, partner_id: partner_id, currency_code: currency_code, line_items: line_items),
+      errors: [],
+    }
+  rescue Errors::ApplicationError => e
+    { order: nil, errors: [e.message] }
+  end
+
+  def validate_user!(user_id)
+    raise Errors::AuthError.new('Not permitted') unless context[:current_user]['partner_ids'].include?(order.partner_id)
+  end
+end

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -1,7 +1,7 @@
 class Mutations::SubmitOrder < Mutations::BaseMutation
   null true
 
-  argument :id, String, required: true
+  argument :id, ID, required: true
   argument :shipping_info, String, required: false
   argument :credit_card_id, String, required: true
 
@@ -12,14 +12,14 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.submit!(order, user_id: user_id, partner_id: partner_id, currency_code: currency_code, line_items: line_items),
+      order: OrderService.submit!(order, credit_card_id: credit_card_id, shipping_info: shipping_info),
       errors: [],
     }
   rescue Errors::ApplicationError => e
     { order: nil, errors: [e.message] }
   end
 
-  def validate_user!(user_id)
+  def validate_request!(order)
     raise Errors::AuthError.new('Not permitted') unless context[:current_user]['partner_ids'].include?(order.partner_id)
   end
 end

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -20,6 +20,6 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
   end
 
   def validate_request!(order)
-    raise Errors::AuthError.new('Not permitted') unless context[:current_user]['partner_ids'].include?(order.partner_id)
+    raise Errors::AuthError.new('Not permitted') unless context[:current_user]['id'] == order.user_id
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,3 +1,4 @@
 class Types::MutationType < Types::BaseObject
   field :create_order, mutation: Mutations::CreateOrder
+  field :submit_order, mutation: Mutations::SubmitOrder
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -8,7 +8,7 @@ class Types::OrderType < Types::BaseObject
   field :partner_id, String, null: false
   field :state, String, null: false
   field :currency_code, String, null: false
-  field :last_state_change_at, Types::DateTimeType, null: false
   field :created_at, Types::DateTimeType, null: false
+  field :update_at, Types::DateTimeType, null: false
   field :line_items, [Types::LineItemType], null: true
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,7 +9,6 @@ class Order < ApplicationRecord
   validates :state, inclusion: { in: STATES }
 
   before_create :set_code
-  before_save :set_last_state_change, if: :state_changed?
   before_save :set_currency_code
 
   scope :pending, -> { where(state: PENDING) }
@@ -18,10 +17,6 @@ class Order < ApplicationRecord
 
   def set_code
     self.code = SecureRandom.hex(10)
-  end
-
-  def set_last_state_change
-    self.last_state_change_at = Time.now.utc
   end
 
   def set_currency_code

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,6 +22,12 @@ class Order < ApplicationRecord
 
   scope :pending, -> { where(state: PENDING) }
 
+  STATES.each do |state|
+    define_method "#{state}?" do
+      self.state == state
+    end
+  end
+
   private
 
   def set_code

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,7 +1,16 @@
 class Order < ApplicationRecord
   STATES = [
     PENDING = 'pending',
-    SUBMITTED = 'submitted'
+    ABANDONED = 'abandoned',
+    # Check-out complete; payment authorized.
+    # Buyer credit card has been authorized and hold has been placed.
+    # At this point, availability must be confirmed manually.
+    # Holds expire 7 days after being placed.
+    SUBMITTED = 'submitted',
+    # Availability has been manually confirmed and hold has been "captured" (debited).
+    APPROVED = 'approved',
+    # Items have been deemed unavailable and hold is voided.
+    REJECTED = 'rejected'
   ]
 
   has_many :line_items, class_name: 'LineItem'

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -9,10 +9,13 @@ module OrderService
     end
   end
 
-  def self.submit(order, shipping_info:, credit_card_id:)
-    # verify price change
-    # hold price on credit card
-    # status submitted
+  def self.submit!(order, shipping_info:, credit_card_id:)
+    Order.transaction do
+      # verify price change?
+      # hold price on credit card
+      order.update_attributes!(state: Order::SUBMITTED, credit_card_id: credit_card_id)
+      # status submitted
+    end
   end
 
   def self.user_pending_artwork_order(user_id, artwork_id, edition_set_id=nil)

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -9,13 +9,15 @@ module OrderService
     end
   end
 
-  def self.submit!(order, shipping_info:, credit_card_id:)
+  def self.submit!(order, credit_card_id:, shipping_info: '')
+    raise Errors::OrderError.new('Order cannot be submitted') unless order.pending?
     Order.transaction do
       # verify price change?
       # hold price on credit card
       order.update_attributes!(state: Order::SUBMITTED, credit_card_id: credit_card_id)
       # status submitted
     end
+    order
   end
 
   def self.user_pending_artwork_order(user_id, artwork_id, edition_set_id=nil)

--- a/db/migrate/20180607135803_add_state_to_orders.rb
+++ b/db/migrate/20180607135803_add_state_to_orders.rb
@@ -2,6 +2,5 @@ class AddStateToOrders < ActiveRecord::Migration[5.2]
   def change
     add_column :orders, :state, :string, default: Order::PENDING
     add_index :orders, :state
-    add_column :orders, :last_state_change_at, :timestamp
   end
 end

--- a/db/migrate/20180611192822_add_credit_card_id_to_order.rb
+++ b/db/migrate/20180611192822_add_credit_card_id_to_order.rb
@@ -1,0 +1,5 @@
+class AddCreditCardIdToOrder < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :credit_card_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_07_135803) do
+ActiveRecord::Schema.define(version: 2018_06_11_192822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2018_06_07_135803) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "state", default: "pending"
+    t.string "credit_card_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,6 @@ ActiveRecord::Schema.define(version: 2018_06_07_135803) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "state", default: "pending"
-    t.datetime "last_state_change_at"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -4,8 +4,9 @@ describe Api::GraphqlController, type: :request do
   describe 'submit_order mutation' do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
+    let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:order) { Fabricate(:order, partner_id: partner_id)}
+    let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id) }
 
     let(:mutation) do
       <<-GRAPHQL
@@ -32,8 +33,8 @@ describe Api::GraphqlController, type: :request do
         }
       }
     end
-    context 'with user without permission to this partner' do
-      let(:partner_id) { 'another-partner-id' }
+    context 'with user without permission to this order' do
+      let(:user_id) { 'random-user-id-on-another-order' }
       it 'returns permission error' do
         response = client.execute(mutation, submit_order_input)
         expect(response.data.submit_order.errors).to include 'Not permitted'

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'submit_order mutation' do
+    include_context 'GraphQL Client'
+    let(:partner_id) { jwt_partner_ids.first }
+    let(:credit_card_id) { 'cc-1' }
+    let(:order) { Fabricate(:order, partner_id: partner_id)}
+
+    let(:mutation) do
+      <<-GRAPHQL
+        mutation($input: SubmitOrderInput!) {
+          submitOrder(input: $input) {
+            order {
+              id
+              userId
+              partnerId
+              state
+            }
+            errors
+          }
+        }
+      GRAPHQL
+    end
+
+    let(:submit_order_input) do
+      {
+        input: {
+          id: order.id.to_s,
+          creditCardId: credit_card_id,
+          shippingInfo: ''
+        }
+      }
+    end
+    context 'with user without permission to this partner' do
+      let(:partner_id) { 'another-partner-id' }
+      it 'returns permission error' do
+        response = client.execute(mutation, submit_order_input)
+        expect(response.data.submit_order.errors).to include 'Not permitted'
+        expect(order.reload.state).to eq Order::PENDING
+      end
+    end
+
+    context 'with order in non-pending state' do
+      before do
+        order.update_attributes! state: Order::APPROVED
+      end
+      it 'returns error' do
+        response = client.execute(mutation, submit_order_input)
+        expect(response.data.submit_order.errors).to include 'Order cannot be submitted'
+        expect(order.reload.state).to eq Order::APPROVED
+      end
+    end
+
+    context 'with proper permission' do
+      it 'submits the order' do
+        response = client.execute(mutation, submit_order_input)
+        expect(response.data.submit_order.order.id).to eq order.id.to_s
+        expect(response.data.submit_order.order.state).to eq Order::SUBMITTED
+        expect(response.data.submit_order.errors).to match []
+        expect(order.reload.credit_card_id).to eq credit_card_id
+        expect(order.state).to eq Order::SUBMITTED
+      end
+    end
+  end
+end

--- a/spec/support/graphlient_client.rb
+++ b/spec/support/graphlient_client.rb
@@ -5,7 +5,7 @@ RSpec.shared_context 'GraphQL Client', shared_context: :metadata do
   let(:jwt_partner_ids) { ['partner-id'] }
   let(:auth_headers) { jwt_headers(user_id: jwt_user_id, partner_ids: jwt_partner_ids) }
   let(:client) do
-    Graphlient::Client.new('https://bearden-test.artsy.net/api/graphql', headers: auth_headers) do |client|
+    Graphlient::Client.new('http://localhost:4000/api/graphql', headers: auth_headers) do |client|
       client.http do |h|
         h.connection do |c|
           c.use Faraday::Adapter::Rack, app


### PR DESCRIPTION
# Problem
As a Collector, I want to be able to Submit my Pending order.
As a Partner user I want to be able to Approve our Submitted orders.

# Solution
- Added new `SubmitOrderMutation` which gets `credit_card_id` and optional `shipping_info` and updates order to submitted order if possible.
  - As part of validation we make sure current user is the owner of this order.
- Added new `ApproveOrderMutaiton` which gets order `id` and updates user status to `approved` if possible.
  - As part of validation we make sure current user has access to the partner of the order.

# Action Based or Generic Mutations?
Originally I tried one [`UpdateOrder` mutation](https://github.com/ashkan18/stress/commit/2baece92a5eb733d2e2ab7f7a017517f7708d11f) which could be used for different update actions possibly can happen to an `Order` but the logic in the Mutation class started getting complicated. 

The idea im trying to keep is, in the Mutation class only do basic validations (like is this person allowed to make this call) and maybe some simple param validation and then just call the service layer method for the actual business logic and more complicated validations (like if any other pending order is around). With that idea, Mutation class for a generic `UpdateOrder` had 2 issues:
- Validation logic would be different based on the new state, when validating user for a submit request we need to make sure its the same user as the order's user while when validating for _approved_ state update we need to make sure current user's partners includes this order's partner (current user has access to order's partner)
- We'd end up not using params validation provided with graphql and possibly confusing the consumers of this mutation:
  - While `shipping_info` is required for a `submit`, we don't need it for `approved` state change in the params. If we want to use same mutation for these two state changes we'd end up making `shipping_info` optional, and it's even possible for someone requesting `approved` state change to pass `shipping_info` which will be totally ignored. With separate mutations we can set 
```
shipping_info, required: true
```
for submit mutation and not have it at all for order update.

# Whats left in submit?
- [ ] We need to call gravity to verify price info and also potentially keep a copy of the artwork at the time of submission in stress.
- [ ] Shipping info? do we store the data in Gravity and pass id here or we store shipping info here?