### PR TITLE
Fix auth to use sub for user id and switch to port 80 on k8s

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::API
       render json: { errors: ['Not Authenticated'] }, status: :unauthorized
       return
     end
-    @current_user = auth_token
+    @current_user = auth_token.with_indifferent_access.merge(id: auth_token[:sub])
   rescue JWT::VerificationError, JWT::DecodeError
     render json: { errors: ['Not Authenticated'] }, status: :unauthorized
   end
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::API
   end
 
   def user_id_in_token?
-    http_token && auth_token && auth_token['id']
+    http_token && auth_token && auth_token['sub']
   end
 
   def decode_token

--- a/app/graphql/mutations/create_order.rb
+++ b/app/graphql/mutations/create_order.rb
@@ -21,6 +21,6 @@ class Mutations::CreateOrder < Mutations::BaseMutation
   end
 
   def validate_user!(user_id)
-    raise Errors::AuthError.new('Not permitted') if context[:current_user]['id'] != user_id
+    raise Errors::AuthError.new('Not permitted') if context[:current_user][:id] != user_id
   end
 end

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -23,9 +23,9 @@ spec:
       - name: stress-web
         env:
         - name: RAILS_SERVE_STATIC_FILES
-          value: true
+          value: 'true'
         - name: RAILS_LOG_TO_STDOUT
-          value: true
+          value: 'true'
         - name: RAILS_ENV
           value: production
         envFrom:
@@ -47,7 +47,7 @@ metadata:
   namespace: default
 spec:
   ports:
-  - port: 8080
+  - port: 80
     protocol: TCP
     targetPort: 8080
   selector:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -31,7 +31,7 @@ spec:
         envFrom:
         - configMapRef:
             name: stress-environment
-        image: None:production
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/stress:production
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -23,9 +23,9 @@ spec:
       - name: stress-web
         env:
         - name: RAILS_SERVE_STATIC_FILES
-          value: true
+          value: 'true'
         - name: RAILS_LOG_TO_STDOUT
-          value: true
+          value: 'true'
         - name: RAILS_ENV
           value: production
         envFrom:
@@ -47,7 +47,7 @@ metadata:
   namespace: default
 spec:
   ports:
-  - port: 8080
+  - port: 80
     protocol: TCP
     targetPort: 8080
   selector:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -31,7 +31,7 @@ spec:
         envFrom:
         - configMapRef:
             name: stress-environment
-        image: None:staging
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/stress:staging
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,5 +1,5 @@
 def jwt_headers(user_id: nil, partner_ids: [])
-  payload_data = { id: user_id, partner_ids: partner_ids }
+  payload_data = { sub: user_id, partner_ids: partner_ids }
   token = JWT.encode(
     payload_data,
     Rails.application.config_for(:jwt)['hmac_secret'],


### PR DESCRIPTION
# Problem
User id comes in `sub` in our token while we were looking for `id`. 
Also use port 80 for the app.