### PR TITLE
Add sidekiq + artwork snapshot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GRAVITY_API_ROOT=https://stagingapi.artsy.net/api
+GRAVITY_JWT=REPLACE
+STRESS_APP_ID=REPLACE

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'puma', '~> 3.11'
 gem 'jwt'
 
 gem 'graphql'
+gem 'hyperclient' # for connecting to hypermedia apis
 gem 'sidekiq'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'puma', '~> 3.11'
 gem 'jwt'
 
 gem 'graphql'
+gem 'sidekiq'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
     crass (1.0.4)
     diff-lcs (1.3)
     erubi (1.7.1)
@@ -91,6 +92,8 @@ GEM
     pg (1.0.0)
     puma (3.11.4)
     rack (2.0.5)
+    rack-protection (2.0.3)
+      rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)
@@ -121,6 +124,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.1)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -139,6 +143,11 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
+    sidekiq (5.1.3)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -168,6 +177,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.0)
   rspec-rails
+  sidekiq
   tzinfo-data
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,11 @@ GEM
     fabrication (2.20.1)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
+    faraday-digestauth (0.3.0)
+      faraday (~> 0.7)
+      net-http-digest_auth (~> 1.4)
+    faraday_hal_middleware (0.1.0)
+      faraday_middleware (~> 0.9)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.25)
@@ -66,6 +71,13 @@ GEM
     graphql-client (0.12.3)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
+    hyperclient (0.9.0)
+      faraday (>= 0.9.0)
+      faraday-digestauth
+      faraday_hal_middleware
+      faraday_middleware
+      net-http-digest_auth
+      uri_template
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jwt (2.1.0)
@@ -86,6 +98,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multipart-post (2.0.0)
+    net-http-digest_auth (1.4.1)
     nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -159,6 +172,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uri_template (0.7.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -171,6 +185,7 @@ DEPENDENCIES
   fabrication
   graphlient
   graphql
+  hyperclient
   jwt
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/jobs/set_line_item_artwork_job.rb
+++ b/app/jobs/set_line_item_artwork_job.rb
@@ -1,0 +1,9 @@
+class SetLineItemArtworkJob < ApplicationJob
+  queue_as :default
+
+  def perform(line_item_id)
+    li = LineItem.find(line_item_id)
+    # Do something later
+    LineItemService.set_artwork_snapshot(li)
+  end
+end

--- a/app/services/artwork_fetch_service.rb
+++ b/app/services/artwork_fetch_service.rb
@@ -1,0 +1,5 @@
+module ArtworkService
+  def self.find(artwork_id)
+    Adapters::GravityV1.request("/artworks/#{artwork_id}")
+  end
+end

--- a/app/services/artwork_fetch_service.rb
+++ b/app/services/artwork_fetch_service.rb
@@ -1,5 +1,0 @@
-module ArtworkService
-  def self.find(artwork_id)
-    Adapters::GravityV1.request("/artworks/#{artwork_id}")
-  end
-end

--- a/app/services/artwork_service.rb
+++ b/app/services/artwork_service.rb
@@ -1,0 +1,26 @@
+module ArtworkService
+  PRIVATE_ARTWORK_FIELDS = %i[price_changed_by flags inventory publish_change_requested_by location deleted_by gene_count partner_gene_count dates external_id display_price_range confidential_notes created_at inventory_id published_changed_at publish_change_requested_at secondary_market deleted dimensions_string].freeze
+
+  def self.find(artwork_id)
+    Adapters::GravityV1.request("/artwork/#{artwork_id}?include_deleted=true")
+  end
+
+  def self.snapshot(artwork_id)
+    item = find(artwork_id)
+    if item[:images]
+      image = item[:images].detect { |img| img[:id] == item[:default_image_id] }
+      image ||= item[:images].first
+      image_urls = image.try(:fetch, :image_urls)
+    else
+      image_urls = {}
+    end
+    permalink = "https://www.artsy.net/artwork/#{item['id']}"
+    properties = item.except(*PRIVATE_ARTWORK_FIELDS)
+    {
+      permalink: permalink,
+      title: item[:title],
+      image_urls: image_urls,
+      properties: properties
+    }
+  end
+end

--- a/app/services/line_item_service.rb
+++ b/app/services/line_item_service.rb
@@ -7,6 +7,12 @@ module LineItemService
       order_id: order.id
     )
     # queue fetching gravity artwork
+    SetLineItemArtworkJob.perform_later(line_item.id)
     line_item
+  end
+
+  def self.set_artwork_snapshot(line_item)
+    artwork_snapshot = ArtworkService.snapshot(line_item.artwork_id)
+    line_item.update_attributes!(artwork_snapshot: artwork_snapshot)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module Stress
     config.eager_load_paths += %W[
       #{Rails.root}/lib
     ]
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module Stress
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.eager_load_paths += %W[
+      #{Rails.root}/lib
+    ]
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-  # PostgreSQL. Versions 9.1 and up are supported.
+# PostgreSQL. Versions 9.1 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.active_job.queue_adapter = :test
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/gravity.yml
+++ b/config/gravity.yml
@@ -1,7 +1,8 @@
 development: &default
   api_v1_root: <%= "#{ENV['GRAVITY_API_ROOT'] || 'https://stagingapi.artsy.net'}/api/v1" %>
-  xapp_token:  <%= ENV['GRAVITY_JWT'] %>
+  xapp_token:  <%= ENV['GRAVITY_JWT'] || 'https://media.giphy.com/media/yow6i0Zmp7G24/giphy.gif' %>
 test:
   <<: *default
+  api_v1_root: 'http://stress-test-gravity.biz'
 production:
   <<: *default

--- a/config/gravity.yml
+++ b/config/gravity.yml
@@ -1,0 +1,7 @@
+development: &default
+  api_v1_root: <%= "#{ENV['GRAVITY_API_ROOT'] || 'https://stagingapi.artsy.net'}/api/v1" %>
+  xapp_token:  <%= ENV['GRAVITY_JWT'] %>
+test:
+  <<: *default
+production:
+  <<: *default

--- a/db/migrate/20180612185116_add_artowrk_snapshot_to_line_items.rb
+++ b/db/migrate/20180612185116_add_artowrk_snapshot_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddArtowrkSnapshotToLineItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :line_items, :artwork_snapshot, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_11_192822) do
+ActiveRecord::Schema.define(version: 2018_06_12_185116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2018_06_11_192822) do
     t.integer "price_cents"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "artwork_snapshot"
     t.index ["order_id"], name: "index_line_items_on_order_id"
   end
 

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -11,8 +11,12 @@ services:
     - RAILS_ENV=test
     - DATABASE_HOST=stress-db
     - DATABASE_USER=postgres
+    - REDIS_URL=redis://stress-redis
     command: ./hokusai/ci.sh
     depends_on:
       - stress-db
+      - stress-redis
   stress-db:
-    image: postgres:9.6
+    image: postgres:9.6-alpine
+  stress-redis:
+    image: redis:3.2-alpine

--- a/lib/adapters/gravity_v1.rb
+++ b/lib/adapters/gravity_v1.rb
@@ -1,0 +1,19 @@
+module Adapters
+  class GravityV1
+    def self.request(url)
+      base_url = "#{Rails.application.config_for(:gravity)['api_v1_root']}#{url}"
+      uri = URI.parse(base_url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      req = Net::HTTP::Get.new("#{uri.path}?#{uri.query}", headers)
+      response = http.request(req)
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    def self.headers
+      {
+        'X-XAPP-TOKEN' => Rails.application.config_for(:gravity)['xapp_token']
+      }
+    end
+  end
+end

--- a/spec/controllers/api/requests/create_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_mutation_request_spec.rb
@@ -58,7 +58,9 @@ describe Api::GraphqlController, type: :request do
           response = client.execute(mutation, order_input_with_line_item)
           expect(response.data.create_order.order.id).not_to be_nil
           expect(response.data.create_order.errors).to match []
-        end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+        end.to change(Order, :count).by(1).and \
+               change(LineItem, :count).by(1).and \
+               have_enqueued_job(SetLineItemArtworkJob)
         order = Order.last
         expect(order.currency_code).to eq 'usd'
         expect(order.user_id).to eq jwt_user_id

--- a/spec/jobs/set_line_item_artwork_job_spec.rb
+++ b/spec/jobs/set_line_item_artwork_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SetLineItemArtworkJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/services/line_item_service_spec.rb
+++ b/spec/services/line_item_service_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe LineItemService, type: :services do
+  include ActiveJob::TestHelper
+  let(:order) { Fabricate(:order) }
+  describe '#create!' do
+    let(:line_item_params) { { artwork_id: 'test-id', edition_set_id: 'ed-1', price_cents: 420_00 } }
+    it 'queues a job to set line item artwork snapshot' do
+      expect do
+        LineItemService.create!(order, line_item_params)
+      end.to have_enqueued_job(SetLineItemArtworkJob)
+    end
+    it 'creates new line item and sets artwork snapshot' do
+      perform_enqueued_jobs do
+        expect(Adapters::GravityV1).to receive(:request).with('/artwork/test-id?include_deleted=true').and_return(gravity_v1_artwork)
+        li = LineItemService.create!(order, line_item_params)
+        expect(li.reload.artwork_id).to eq 'test-id'
+        expect(li.edition_set_id).to eq 'ed-1'
+        expect(li.price_cents).to eq 420_00
+        artwork_snapshot = li.artwork_snapshot.with_indifferent_access
+        expect(artwork_snapshot[:permalink]).to eq 'https://www.artsy.net/artwork/cat'
+        expect(artwork_snapshot[:title]).to eq 'Cat'
+        expect(artwork_snapshot[:image_urls]['cats']).to eq '/path/to/cats.jpg'
+      end
+    end
+  end
+  describe '#set_artwork_snapshot' do
+    let(:line_item) { Fabricate(:line_item, artwork_id: 'test-id', edition_set_id: 'ed-1') }
+    it 'fetches the artwork and constructs the appropriate hash of snapshotted attributes' do
+      expect(Adapters::GravityV1).to receive(:request).with('/artwork/test-id?include_deleted=true').and_return(gravity_v1_artwork)
+      LineItemService.set_artwork_snapshot(line_item)
+      artwork_snapshot = line_item.reload.artwork_snapshot.with_indifferent_access
+      expect(artwork_snapshot[:permalink]).to eq 'https://www.artsy.net/artwork/cat'
+      expect(artwork_snapshot[:title]).to eq 'Cat'
+      expect(artwork_snapshot[:image_urls]['cats']).to eq '/path/to/cats.jpg'
+      scrubbed_artwork = gravity_v1_artwork
+      scrubbed_artwork.delete('confidential_notes')
+      expect(artwork_snapshot[:properties]).to eq scrubbed_artwork
+    end
+  end
+end

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -1,0 +1,12 @@
+def gravity_v1_artwork(options: {})
+  {
+    'id' => 'cat',
+    'title' => 'Cat',
+    'default_image_id' => 'image',
+    'images' => [{
+      'id' => 'image',
+      'image_urls' => { 'cats' => '/path/to/cats.jpg' }
+    }],
+    'confidential_notes' => 'sssh'
+  }.merge(options).with_indifferent_access
+end


### PR DESCRIPTION
# Change
We want to store artwork data at the time of order creation on the `LineItem`.

# Solution
Added Sidekiq so we can queue job for fetching Artwork from Gravity when we create new line item.

Added `Adapters::GravityV1` endpoint (pretty much copied from [Impulse](https://github.com/artsy/impulse/blob/master/lib/adapters/gravity_v1.rb)). We most likely will need to make more V1 calls for processing charges and stuff so not using V2 at the moment.

Added `artwork_snapshot` to `LineItem` model, one thing to think of is to decide what/how we need to store on this model, current solution doesn't make much sense, I have `title`, `images`, `permalink` in their own key and `properties` being the filtered response from Gravity.
There was a discussion about this in Impulse a while ago but here we need to decide what we need to store.