### PR TITLE
Add spec for orders query

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -10,5 +10,5 @@ class Types::OrderType < Types::BaseObject
   field :currency_code, String, null: false
   field :created_at, Types::DateTimeType, null: false
   field :update_at, Types::DateTimeType, null: false
-  field :line_items, [Types::LineItemType], null: true
+  field :line_items, Types::LineItemType.connection_type, null: true
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -16,7 +16,14 @@ class Types::QueryType < Types::BaseObject
 
   def order(id:)
     order = Order.find(id)
-    raise GraphQL::ExecutionError, 'permission error' unless order.user_id == context[:current_user][:id]
+    raise GraphQL::ExecutionError, 'permission error' unless order.user_id == context[:current_user][:id] || context[:current_user][:partner_ids].include?(order.partner_id)
     order
+  end
+
+  def orders(params)
+    raise GraphQL::ExecutionError, 'requires one of userId or partnerId' unless params[:user_id].present? || params[:partner_id].present?
+    raise GraphQL::ExecutionError, 'Not permitted' if params[:user_id] && params[:user_id] != context[:current_user][:id]
+    raise GraphQL::ExecutionError, 'Not permitted' if params[:partner_id] && !context[:current_user][:partner_ids].include?(params[:partner_id])
+    Order.where(params)
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,7 +7,7 @@ class Types::QueryType < Types::BaseObject
     argument :id, ID, required: true
   end
 
-  field :orders, [Types::OrderType], null: true do
+  field :orders, Types::OrderType.connection_type, null: true do
     description "Find list of orders"
     argument :user_id, String, required: false
     argument :partner_id, String, required: false

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'orders query' do
+    include_context 'GraphQL Client'
+    let(:partner_id) { jwt_partner_ids.first }
+    let(:second_partner_id) { 'partner-2' }
+    let(:user_id) { jwt_user_id }
+    let(:second_user) { 'user2' }
+    let!(:user1_order1) { Fabricate(:order, partner_id: partner_id, user_id: user_id) }
+    let!(:user1_order2) { Fabricate(:order, partner_id: second_partner_id, user_id: user_id) }
+    let!(:user2_order1) { Fabricate(:order, partner_id: partner_id, user_id: second_user) }
+
+    let(:query) do
+      <<-GRAPHQL
+        query($userId: String, $partnerId: String, $state: String) {
+          orders(userId: $userId, partnerId: $partnerId, state: $state) {
+            id
+            userId
+            partnerId
+            state
+          }
+        }
+      GRAPHQL
+    end
+
+    it 'returns error when missing both userId and partnerId' do
+      expect do
+        client.execute(query, state: 'pending')
+      end.to raise_error(Graphlient::Errors::ExecutionError, 'orders: requires one of userId or partnerId')
+    end
+
+    context 'query with partnerId' do
+      it 'returns permission error when query for partnerId not in jwt' do
+        expect do
+          client.execute(query, partnerId: 'someone-elses-partnerid')
+        end.to raise_error(Graphlient::Errors::ExecutionError, 'orders: Not permitted')
+      end
+    end
+
+    context 'query with userId' do
+      it 'returns permission error when query for user not in jwt' do
+        expect do
+          client.execute(query, userId: 'someone-elses-userid')
+        end.to raise_error(Graphlient::Errors::ExecutionError, 'orders: Not permitted')
+      end
+
+      it 'returns users orders' do
+        results = client.execute(query, userId: user_id)
+        expect(results.data.orders.count).to eq 2
+        expect(results.data.orders.map(&:id)).to match_array([user1_order1.id, user1_order2.id].map(&:to_s))
+      end
+
+      it 'returns partners orders' do
+        results = client.execute(query, partnerId: partner_id)
+        expect(results.data.orders.count).to eq 2
+        expect(results.data.orders.map(&:id)).to match_array([user1_order1.id, user2_order1.id].map(&:to_s))
+      end
+    end
+  end
+end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -15,10 +15,14 @@ describe Api::GraphqlController, type: :request do
       <<-GRAPHQL
         query($userId: String, $partnerId: String, $state: String) {
           orders(userId: $userId, partnerId: $partnerId, state: $state) {
-            id
-            userId
-            partnerId
-            state
+            edges{
+              node{
+                id
+                userId
+                partnerId
+                state
+              }
+            }
           }
         }
       GRAPHQL
@@ -47,14 +51,14 @@ describe Api::GraphqlController, type: :request do
 
       it 'returns users orders' do
         results = client.execute(query, userId: user_id)
-        expect(results.data.orders.count).to eq 2
-        expect(results.data.orders.map(&:id)).to match_array([user1_order1.id, user1_order2.id].map(&:to_s))
+        expect(results.data.orders.edges.count).to eq 2
+        expect(results.data.orders.edges.map(&:node).map(&:id)).to match_array([user1_order1.id, user1_order2.id].map(&:to_s))
       end
 
       it 'returns partners orders' do
         results = client.execute(query, partnerId: partner_id)
-        expect(results.data.orders.count).to eq 2
-        expect(results.data.orders.map(&:id)).to match_array([user1_order1.id, user2_order1.id].map(&:to_s))
+        expect(results.data.orders.edges.count).to eq 2
+        expect(results.data.orders.edges.map(&:node).map(&:id)).to match_array([user1_order1.id, user2_order1.id].map(&:to_s))
       end
     end
   end


### PR DESCRIPTION
Support query by partners based on user's jwt token and more spec.

Also as part of this, we replaces usages of `[]` for returning array of things to `connection_type` so now `orders` query returns a `connection` which means we now support all connection related pagination support and also we need to get the results using `edges` and `node`.

https://dev-blog.apollodata.com/explaining-graphql-connections-c48b7c3d6976

# Selfie

![screen shot 2018-06-18 at 9 58 02 am](https://user-images.githubusercontent.com/1230819/41540391-2f02eeb8-72de-11e8-935e-99558ea1b563.png)
