### PR TITLE
Remove shipping info from submit order mutation

### DIFF
--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -2,17 +2,16 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
   null true
 
   argument :id, ID, required: true
-  argument :shipping_info, String, required: false
   argument :credit_card_id, String, required: true
 
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false
 
-  def resolve(id:, shipping_info:, credit_card_id:)
+  def resolve(id:, credit_card_id:)
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.submit!(order, credit_card_id: credit_card_id, shipping_info: shipping_info),
+      order: OrderService.submit!(order, credit_card_id: credit_card_id),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -28,8 +28,7 @@ describe Api::GraphqlController, type: :request do
       {
         input: {
           id: order.id.to_s,
-          creditCardId: credit_card_id,
-          shippingInfo: ''
+          creditCardId: credit_card_id
         }
       }
     end


### PR DESCRIPTION
Removing shipping info from submit order mutation until we have clarity around what data we want and how it should be stored.